### PR TITLE
Fix issue #3

### DIFF
--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -459,11 +459,11 @@ Logger::~Logger()
 
   // Cleanup appenders
   QMutexLocker appendersLocker(&d->appendersMutex);
-  foreach (AbstractAppender* appender, d->appenders)
-    delete appender;
+  qDeleteAll(d->appenders);
 
   // Cleanup device
   delete d->logDevice;
+  appendersLocker.unlock();
 
   delete d_ptr;
 }


### PR DESCRIPTION
As described in #3, the main object can't be deleted since a mutex which live in its d-pointer prevent the deletion. Because of that, application using CuteLogger never stop.

This simple commit fix the error by unlocking the mutex just before deleting the d-pointer.
