### PR TITLE
Rolling logfile when starting if needed

### DIFF
--- a/src/RollingFileAppender.cpp
+++ b/src/RollingFileAppender.cpp
@@ -144,7 +144,17 @@ void RollingFileAppender::computeRollOverTime()
 {
   Q_ASSERT_X(!m_datePatternString.isEmpty(), "DailyRollingFileAppender::computeRollOverTime()", "No active date pattern");
 
-  QDateTime now = QDateTime::currentDateTime();
+  QDateTime now;
+
+  QFileInfo fileInfo = QFileInfo(this->fileName());
+  if(fileInfo.isFile()){
+    now = fileInfo.lastModified();
+  }
+
+  if(!now.isValid() || now > QDateTime::currentDateTime()){
+    now = QDateTime::currentDateTime();
+  }
+
   QDate nowDate = now.date();
   QTime nowTime = now.time();
   QDateTime start;


### PR DESCRIPTION
The rolling is working if the application is not shutdown over night (for daily). 

Solved by getting the modification time from file if it exists when starting the application and using it instead of now.
