### PR TITLE
Qt5 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,13 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 
 PROJECT(CuteLogger)
 
-FIND_PACKAGE(Qt4 COMPONENTS QtCore REQUIRED)
-INCLUDE(${QT_USE_FILE})
+OPTION(USE_Qt5 "Use Qt5 instead of Qt4 (default)" OFF)
+if(USE_Qt5)
+  FIND_PACKAGE(Qt5Core REQUIRED)
+else(USE_Qt5) # default is Qt4
+  FIND_PACKAGE(Qt4 COMPONENTS QtCore REQUIRED)
+  INCLUDE(${QT_USE_FILE})
+endif(USE_Qt5)
 
 ADD_DEFINITIONS(-DCUTELOGGER_LIBRARY)
 
@@ -40,4 +45,17 @@ SET(library_target Logger)
 
 ADD_LIBRARY(${library_target} SHARED ${sources} ${includes})
 TARGET_LINK_LIBRARIES(${library_target} ${QT_LIBRARIES})
+if(USE_Qt5)
+  QT5_USE_MODULES(${library_target} Core)
+endif(USE_Qt5)
 INSTALL(TARGETS ${library_target} DESTINATION lib)
+
+SET(CuteLogger_PATH_SUFFIX cutelogger)
+INSTALL(FILES
+        ${includes} cmake/CuteLoggerConfig.cmake
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${CuteLogger_PATH_SUFFIX})
+INSTALL(TARGETS
+        ${library_target}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin/${CuteLogger_PATH_SUFFIX}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${CuteLogger_PATH_SUFFIX}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${CuteLogger_PATH_SUFFIX})

--- a/cmake/CuteLoggerConfig.cmake
+++ b/cmake/CuteLoggerConfig.cmake
@@ -1,0 +1,32 @@
+# Try to find CuteLogger. Once done, this will define:
+#
+#  CuteLogger_INCLUDE_DIR - the NiftyMatch include directories
+#  CuteLogger_LIBS - link these to use NiftyMatch
+#
+
+# to be kept in sync with CMakeLists.txt at top level
+# allows defined suffix to be appended to all searched paths
+SET(CuteLogger_PATH_SUFFIX cutelogger)
+
+# Include dir
+FIND_PATH(CuteLogger_INCLUDE_DIR
+	NAMES Logger.h
+	PATHS ${CMAKE_CURRENT_LIST_DIR}/../../include
+	PATH_SUFFIXES ${CuteLogger_PATH_SUFFIX})
+
+# And the modules of this library
+FIND_LIBRARY(CuteLogger_LIB
+	NAMES Logger
+	PATHS ${CMAKE_CURRENT_LIST_DIR}/../../lib
+	PATH_SUFFIXES ${CuteLogger_PATH_SUFFIX})
+
+# Put them all into a var
+SET(CuteLogger_LIBS
+	${CuteLogger_LIB})
+
+# handle the QUIETLY and REQUIRED arguments and set CuteLogger_FOUND
+# if all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+	CuteLogger DEFAULT_MSG
+	CuteLogger_LIBS CuteLogger_INCLUDE_DIR)


### PR DESCRIPTION
Hi there,

I've added some CMake configuration options to make CuteLogger compatible with Qt5 as well, while keeping Qt4 as the default. As such, to use Qt5, specify `-D USE_Qt5=ON` when building.

I've also added a CMake find file and install options that allow for `-D CuteLogger_DIR=/path/to/CuteLoggerConfig.cmake` to be used when building other projects that depend on CuteLogger. Now `make install` installs to `${CMAKE_INSTALL_PREFIX}/include/cutelogger/` and `${CMAKE_INSTALL_PREFIX}/lib/cutelogger/`

Thanks for this nice library. I'm using it for thread-safe logging to the console and file.

Cheers,
Dzhoshkun