### PR TITLE
add CuteLogger.pri and source build feature

### DIFF
--- a/CuteLogger.pri
+++ b/CuteLogger.pri
@@ -1,0 +1,26 @@
+INCLUDEPATH += ./include
+
+SOURCES += src/Logger.cpp \
+           src/AbstractAppender.cpp \
+           src/AbstractStringAppender.cpp \
+           src/ConsoleAppender.cpp \
+           src/FileAppender.cpp \
+           src/RollingFileAppender.cpp
+
+HEADERS += include/Logger.h \
+           include/CuteLogger_global.h \
+           include/AbstractAppender.h \
+           include/AbstractStringAppender.h \
+           include/ConsoleAppender.h \
+           include/FileAppender.h \
+           include/RollingFileAppender.h
+
+win32 {
+    SOURCES += src/OutputDebugAppender.cpp
+    HEADERS += include/OutputDebugAppender.h
+}
+
+android {
+    SOURCES += src/AndroidAppender.cpp
+    HEADERS += include/AndroidAppender.h
+}

--- a/CuteLogger.pro
+++ b/CuteLogger.pro
@@ -5,32 +5,7 @@ TEMPLATE = lib
 
 DEFINES += CUTELOGGER_LIBRARY
 
-INCLUDEPATH += ./include
-
-SOURCES += src/Logger.cpp \
-           src/AbstractAppender.cpp \
-           src/AbstractStringAppender.cpp \
-           src/ConsoleAppender.cpp \
-           src/FileAppender.cpp \
-           src/RollingFileAppender.cpp
-
-HEADERS += include/Logger.h \
-           include/CuteLogger_global.h \
-           include/AbstractAppender.h \
-           include/AbstractStringAppender.h \
-           include/ConsoleAppender.h \
-           include/FileAppender.h \
-           include/RollingFileAppender.h
-
-win32 {
-    SOURCES += src/OutputDebugAppender.cpp
-    HEADERS += include/OutputDebugAppender.h
-}
-
-android {
-    SOURCES += src/AndroidAppender.cpp
-    HEADERS += include/AndroidAppender.h
-}
+include(./CuteLogger.pri)
 
 symbian {
     MMP_RULES += EXPORTUNFROZEN

--- a/include/CuteLogger_global.h
+++ b/include/CuteLogger_global.h
@@ -1,12 +1,18 @@
-#ifndef CUTELOGGER_GLOBAL_H
+﻿#ifndef CUTELOGGER_GLOBAL_H
 #define CUTELOGGER_GLOBAL_H
 
 #include <QtCore/qglobal.h>
+
+#if defined(CUTELOGGER_USE_SRC)
+#  define CUTELOGGERSHARED_EXPORT
+#else
 
 #if defined(CUTELOGGER_LIBRARY)
 #  define CUTELOGGERSHARED_EXPORT Q_DECL_EXPORT
 #else
 #  define CUTELOGGERSHARED_EXPORT Q_DECL_IMPORT
+#endif
+
 #endif
 
 #endif // CUTELOGGER_GLOBAL_H


### PR DESCRIPTION
1. move head and source files to CuteLogger.pri.
2. 	add macro CUTELOGGER_USE_SRC use to include source files in another project directly